### PR TITLE
Skip tests in Release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
               uses: ballerina-platform/ballerina-action@slbeta3
               with:
                   args:
-                      build -c ./calendar
+                      build -c --skip-tests ./calendar
               env:
                   REFRESH_URL: ${{ secrets.REFRESH_URL }}
                   REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}


### PR DESCRIPTION
## Description
During release, both Ci and Release workflows run concurrently and test cases fail.
To avoid this, skipping tests in release.yml