### PR TITLE
fix build warnings & add entry to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ hs_err_pid*
 .gradle
 
 # Ignore build
-*/build/
+**/build/

--- a/calendar/stream_implementer.bal
+++ b/calendar/stream_implementer.bal
@@ -53,6 +53,7 @@ class EventStream {
             self.index += 1;
             return singleRecord;
         }
+        return;
     }
 
     isolated function fetchRecordsInitial() returns Event[]|error {
@@ -124,6 +125,7 @@ class CalendarStream {
             self.index += 1;
             return singleRecord;
         }
+        return;
     }
 
     isolated function fetchRecordsInitial() returns Calendar[]|error {

--- a/calendar/tests/test.bal
+++ b/calendar/tests/test.bal
@@ -101,19 +101,20 @@ function testGetEventWithQueryParameters() {
     io:println("\n\n");
 }
 
-# Test - Get list of `Events` 
+# Test - Get list of `Events`
+# + return - error or null on failure.
 @test:Config {
     enable: true,
     groups: ["events"]
 }
-function testListEvents() {
+function testListEvents() returns error? {
     log:printInfo("client->testListEvents()"); 
     stream<Event, error?>|error eventStream 
         = calendarClient->listEvents(timeZone=TIMEZONE_AD, contentType=CONTENT_TYPE_TEXT, queryParams = queryParamTop);
     if (eventStream is stream<Event, error?>) {
-        error? e = eventStream.forEach(isolated function (Event event) {
+        _ = check eventStream.forEach(isolated function (Event event) {
             test:assertNotEquals(event.id, EMPTY_STRING, "Empty Event ID");
-           log:printInfo(event.id.toString());
+            log:printInfo(event.id.toString());
         }); 
     } else {
         test:assertFail(msg = eventStream.message());
@@ -392,18 +393,19 @@ function testUpdateCalendar() {
     io:println("\n\n");
 }
 
-# Test - List `Calendars`  
+# Test - List `Calendars` 
+# + return - error or null on failure. 
 @test:Config {
     enable: true,
     groups: ["calendars"],
     before: testCreateCalendar,
     after: testDeleteCalendar
 }
-function testListCalendars() {
+function testListCalendars() returns error? {
     log:printInfo("client->testListCalendars()"); 
     stream<Calendar, error?>|error eventStream = calendarClient->listCalendars(queryParams = queryParamTop);
     if (eventStream is stream<Calendar, error?>) {
-        error? e = eventStream.forEach(isolated function (Calendar calendar) {
+        _ = check eventStream.forEach(isolated function (Calendar calendar) {
             test:assertNotEquals(calendar.id.toString(), EMPTY_STRING, "Empty Calender ID.");
             log:printInfo(calendar.id.toString());
         });


### PR DESCRIPTION
# Description

- fix build warning issues.
- Added an entry to gitignore

Example: 

```
WARNING [stream_implementer.bal:(114:45,114:78)] this function should explicitly return a value
WARNING [tests/test.bal:(104:1,104:30)] undocumented return parameter
WARNING [utils.bal:(321:17,321:118)] unused variable 'streams'
```

One line release note: 
- fix build warning issues

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: slbeta6rc1
* Operating System: ubuntu
* Java SDK: Java11

# Checklist:

### Security checks
 - [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
